### PR TITLE
Provide an example of an external cross-origin visit redirect

### DIFF
--- a/server.js
+++ b/server.js
@@ -75,6 +75,10 @@ app.get("/redirected", (request, response) => {
   response.render("redirected", { title: "Redirected Page" })
 })
 
+app.get("/follow-external-redirect", (request, response) => {
+  response.redirect("https://37signals.com")
+})
+
 app.get("/reference", (request, response) => {
   response.render("reference", { title: "Reference", page_class: "index" })
 })

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -53,6 +53,10 @@
       <div class="actions__icon --redirect" aria-hidden="true"></div>
       Follow a redirect
     </a>
+    <a class="actions__item" href="/follow-external-redirect">
+      <div class="actions__icon --redirect" aria-hidden="true"></div>
+      Follow an external redirect
+    </a>
     <a class="actions__item" href="/files">
       <div class="actions__icon --files" aria-hidden="true"></div>
       See how files work


### PR DESCRIPTION
This demonstrates how cross-origin visit redirects work in the iOS and Android libraries. This corresponds to changes made in these PRs:
- https://github.com/hotwired/hotwire-native-android/pull/82
- https://github.com/hotwired/hotwire-native-ios/pull/70